### PR TITLE
Daemonize yowsup configuration

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,4 +47,10 @@ You can have a multiple workers for different phone numbers routing each worker 
 When calling tasks queue to the queue desired::
 
 	taks.connect.apply_async(queue="number1")	
+	
+If you want to use celery as daemon just add yowconfig path in configuration::
+
+	app.conf.update(
+	   YOWSUPCONFIG='path/to/yowsupconfig/file'          
+     )
 

--- a/example/celery.py
+++ b/example/celery.py
@@ -25,6 +25,7 @@ app = YowCelery('example',
              include=['yowsup_celery.tasks'])
 
 # Feel free to add other layers 
-# app.conf.update(
-#     TOP_LAYERS=('yowsup_ext.layers.store.layer.YowStorageLayer',)          
+#app.conf.update(
+#     TOP_LAYERS=('yowsup_ext.layers.store.layer.YowStorageLayer',)  
+#    YOWSUPCONFIG='example/conf_wasap'        
 #     )

--- a/tests/test_bootsteps.py
+++ b/tests/test_bootsteps.py
@@ -50,6 +50,14 @@ class TestYowsupStep(unittest.TestCase):
         
     def test_init_no_configuration_method(self):
         self.assertRaises(ConfigurationError, YowsupStep, self.worker, None, None, True)
+    
+    def test_init_conf_file_only_in_configuration(self):
+        with mock.patch('six.moves.builtins.open', mock.mock_open(read_data='adasdasd')) as m:
+            handle = m.return_value.__enter__.return_value
+            handle.__iter__.return_value = iter(["####confifle\n", "phone=341111111\n", "password=asdasdasdasd\n"])
+            self.worker.app.conf.table = mock.MagicMock(return_value={'YOWSUPCONFIG': 'file_path'})
+            YowsupStep(self.worker, None, None, True)
+            self.assertStackIntiliazed(self.worker.app.stack)
         
     def test_init_top_layer_not_interface_layer(self):
         self.worker.app.conf.table = mock.MagicMock(return_value={'TOP_LAYERS': ('yowsup.stacks.yowstack.YowStack',)})


### PR DESCRIPTION
Using celery in daemon mode it was not possible to set `yowsupconfig` as parameter.
Now it is allowed to use `YOWSUPCONFIG` to configure path for yowsup authentication. 

It should fix issues: #2 #3 
